### PR TITLE
py3 needs urlopen from urllib.request

### DIFF
--- a/src/pykml/parser.py
+++ b/src/pykml/parser.py
@@ -5,7 +5,11 @@ from a file or remote URL.
 '''
 import sys
 import os
-import urllib2
+try:
+    from urllib2 import urlopen
+except:
+    from urllib.request import urlopen
+
 from lxml import etree, objectify
 
 OGCKML_SCHEMA = 'http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd'
@@ -21,7 +25,7 @@ class Schema():
                 self.schema = etree.XMLSchema(file=f)
         except:
             # try to open a remote URL
-            f = urllib2.urlopen(schema)
+            f = urlopen(schema)
             self.schema = etree.XMLSchema(file=f)
     
     def validate(self, doc):
@@ -91,7 +95,7 @@ def validate_kml():
         fileobject = open(uri)
     except IOError:
         try:
-            fileobject = urllib2.urlopen(uri)
+            fileobject = urlopen(uri)
         except ValueError:
             raise ValueError('Unable to load URI {0}'.format(uri))
     except:


### PR DESCRIPTION
Just seen as we ported our mss tool to py3.

For us this seems to be the only change to be done