### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 import sys, os
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+
+from setuptools import setup
 
 version = '0.2.0'
 


### PR DESCRIPTION
`setup.py` still uses the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [platform](https://docs.python.org/3/library/platform.html#module-platform), [shutil](https://docs.python.org/3/library/shutil.html#module-shutil), [subprocess](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [sysconfig](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

[Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools) suggests using `setuptools.setup` instead of `distutils.core.setup`.

Because `setup_requires` is deprecated, [PEP 517 (`pyproject.toml`)](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement) is used for the build time dependencies.